### PR TITLE
feat: add lazy select

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "it-first": "^1.0.6",
     "it-handshake": "^4.0.1",
     "it-length-prefixed": "^8.0.2",
+    "it-merge": "^1.0.4",
     "it-pipe": "^2.0.3",
     "it-pushable": "^3.0.0",
     "it-reader": "^6.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,5 +21,5 @@ export interface MultistreamSelectInit extends AbortOptions {
   writeBytes?: boolean
 }
 
-export { select } from './select.js'
+export { select, lazySelect } from './select.js'
 export { handle } from './handle.js'

--- a/src/select.ts
+++ b/src/select.ts
@@ -70,7 +70,9 @@ export async function select (stream: Duplex<any>, protocols: string | string[],
  *
  * Use when it is known that the receiver supports the desired protocol.
  */
-export function lazySelect (stream: Duplex<Uint8Array>, protocol: string): ProtocolStream<Uint8Array> {
+export function lazySelect (stream: Duplex<Uint8Array>, protocol: string): ProtocolStream<Uint8Array>
+export function lazySelect (stream: Duplex<Uint8ArrayList, Uint8ArrayList | Uint8Array>, protocol: string): ProtocolStream<Uint8ArrayList, Uint8ArrayList | Uint8Array>
+export function lazySelect (stream: Duplex<any>, protocol: string): ProtocolStream<any> {
   // This is a signal to write the multistream headers if the consumer tries to
   // read from the source
   const negotiateTrigger = pushable()
@@ -84,6 +86,7 @@ export function lazySelect (stream: Duplex<Uint8Array>, protocol: string): Proto
           if (first) {
             first = false
             negotiated = true
+            negotiateTrigger.end()
             const p1 = uint8ArrayFromString(PROTOCOL_ID)
             const p2 = uint8ArrayFromString(protocol)
             const list = new Uint8ArrayList(multistream.encode(p1), multistream.encode(p2))

--- a/src/select.ts
+++ b/src/select.ts
@@ -5,7 +5,10 @@ import { handshake } from 'it-handshake'
 import { fromString as uint8ArrayFromString } from 'uint8arrays/from-string'
 import { PROTOCOL_ID } from './index.js'
 import type { Duplex } from 'it-stream-types'
-import type { Uint8ArrayList } from 'uint8arraylist'
+import { Uint8ArrayList } from 'uint8arraylist'
+import { pushable } from 'it-pushable'
+import merge from 'it-merge'
+import { reader } from 'it-reader'
 import type { ByteArrayInit, ByteListInit, MultistreamSelectInit, ProtocolStream } from './index.js'
 
 const log = logger('libp2p:mss:select')
@@ -57,4 +60,60 @@ export async function select (stream: Duplex<any>, protocols: string | string[],
 
   rest()
   throw errCode(new Error('protocol selection failed'), 'ERR_UNSUPPORTED_PROTOCOL')
+}
+
+/**
+ * Lazily negotiates a protocol.
+ *
+ * It *does not* block writes waiting for the other end to respond. Instead, it
+ * simply assumes the negotiation went successfully and starts writing data.
+ *
+ * Use when it is known that the receiver supports the desired protocol.
+ */
+export function lazySelect (stream: Duplex<Uint8Array>, protocol: string): ProtocolStream<Uint8Array> {
+  // This is a signal to write the multistream headers if the consumer tries to
+  // read from the source
+  const readPusher = pushable()
+  return {
+    stream: {
+      // eslint-disable-next-line @typescript-eslint/promise-function-async
+      sink: source => {
+        return stream.sink((async function * () {
+          let first = true
+          for await (const chunk of merge(source, readPusher)) {
+            if (first) {
+              const p1 = uint8ArrayFromString(PROTOCOL_ID)
+              const p2 = uint8ArrayFromString(protocol)
+              const list = new Uint8ArrayList(multistream.encode(p1), multistream.encode(p2))
+              if (chunk.length !== 0) { // chunk will be zero length if from the pushable
+                list.append(chunk)
+              }
+              yield list.slice()
+              first = false
+            }
+            yield chunk
+          }
+        })())
+      },
+      source: (async function * () {
+        readPusher.push(new Uint8Array())
+        try {
+          const byteReader = reader(stream.source)
+          let response = await multistream.readString(byteReader)
+          if (response === PROTOCOL_ID) {
+            response = await multistream.readString(byteReader)
+          }
+          if (response !== protocol) {
+            throw errCode(new Error('protocol selection failed'), 'ERR_UNSUPPORTED_PROTOCOL')
+          }
+          for await (const chunk of byteReader) {
+            yield chunk.slice()
+          }
+        } catch (err) {
+          if (err.code !== 'ERR_UNDER_READ') throw err
+        }
+      })()
+    },
+    protocol
+  }
 }

--- a/src/select.ts
+++ b/src/select.ts
@@ -79,8 +79,7 @@ export function lazySelect (stream: Duplex<any>, protocol: string): ProtocolStre
   let negotiated = false
   return {
     stream: {
-      // eslint-disable-next-line @typescript-eslint/promise-function-async
-      sink: source => stream.sink((async function * () {
+      sink: async source => await stream.sink((async function * () {
         let first = true
         for await (const chunk of merge(source, negotiateTrigger)) {
           if (first) {
@@ -91,7 +90,7 @@ export function lazySelect (stream: Duplex<any>, protocol: string): ProtocolStre
             const p2 = uint8ArrayFromString(protocol)
             const list = new Uint8ArrayList(multistream.encode(p1), multistream.encode(p2))
             if (chunk.length > 0) list.append(chunk)
-            yield list.slice()
+            yield * list
           } else {
             yield chunk
           }
@@ -108,7 +107,7 @@ export function lazySelect (stream: Duplex<any>, protocol: string): ProtocolStre
           throw errCode(new Error('protocol selection failed'), 'ERR_UNSUPPORTED_PROTOCOL')
         }
         for await (const chunk of byteReader) {
-          yield chunk.slice()
+          yield * chunk
         }
       })()
     },

--- a/test/dialer.spec.ts
+++ b/test/dialer.spec.ts
@@ -116,4 +116,19 @@ describe('Dialer', () => {
       await expect(mss.select(duplex, protocol)).to.eventually.be.rejected().with.property('code', 'ERR_UNSUPPORTED_PROTOCOL')
     })
   })
+
+  describe('dialer.lazySelect', () => {
+    it('should lazily select a single protocol', async () => {
+      const protocol = '/echo/1.0.0'
+      const duplex = pair()
+
+      const selection = mss.lazySelect(duplex, protocol)
+      expect(selection.protocol).to.equal(protocol)
+
+      // Ensure stream is usable after selection
+      const input = [randomBytes(10), randomBytes(64), randomBytes(3)]
+      const output = await pipe(input, selection.stream, async (source) => await all(source))
+      expect(new Uint8ArrayList(...output).slice()).to.eql(new Uint8ArrayList(...input).slice())
+    })
+  })
 })

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -116,10 +116,10 @@ describe('Dialer and Listener integration', () => {
     // The error message from this varies depending on how much data got
     // written when the dialer receives the `na` response and closes the
     // stream, so we just assert that this rejects.
-    await expect(mss.handle(pair[1], '/unhandled/1.0.0')).to.be.rejected()
+    await expect(mss.handle(pair[1], '/unhandled/1.0.0')).to.eventually.be.rejected()
 
-    const dialerErr = await expect(dialerResultPromise).to.be.rejected()
     // Dialer should fail to negotiate the single protocol
-    expect(dialerErr.code).to.eql('ERR_UNSUPPORTED_PROTOCOL')
+    await expect(dialerResultPromise).to.eventually.be.rejected()
+      .with.property('code', 'ERR_UNSUPPORTED_PROTOCOL')
   })
 })

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -79,4 +79,47 @@ describe('Dialer and Listener integration', () => {
     ])
     expect(new Uint8ArrayList(...output[0]).slice()).to.eql(new Uint8ArrayList(...input).slice())
   })
+
+  it('should handle and lazySelect', async () => {
+    const protocol = '/echo/1.0.0'
+    const pair = duplexPair()
+
+    const dialerSelection = mss.lazySelect(pair[0], protocol)
+    expect(dialerSelection.protocol).to.equal(protocol)
+
+    // Ensure stream is usable after selection
+    const input = [new Uint8ArrayList(randomBytes(10), randomBytes(64), randomBytes(3))]
+    // Since the stream is lazy, we need to write to it before handling
+    const dialerOutPromise = pipe(input, dialerSelection.stream, async source => await all(source))
+
+    const listenerSelection = await mss.handle(pair[1], protocol)
+    expect(listenerSelection.protocol).to.equal(protocol)
+
+    await pipe(listenerSelection.stream, listenerSelection.stream)
+
+    const dialerOut = await dialerOutPromise
+    expect(new Uint8ArrayList(...dialerOut).slice()).to.eql(new Uint8ArrayList(...input).slice())
+  })
+
+  it('should abort an unhandled lazySelect', async () => {
+    const protocol = '/echo/1.0.0'
+    const pair = duplexPair()
+
+    const dialerSelection = mss.lazySelect(pair[0], protocol)
+    expect(dialerSelection.protocol).to.equal(protocol)
+
+    // Ensure stream is usable after selection
+    const input = [new Uint8ArrayList(randomBytes(10), randomBytes(64), randomBytes(3))]
+    // Since the stream is lazy, we need to write to it before handling
+    const dialerResultPromise = pipe(input, dialerSelection.stream, async source => await all(source))
+
+    // The error message from this varies depending on how much data got
+    // written when the dialer receives the `na` response and closes the
+    // stream, so we just assert that this rejects.
+    await expect(mss.handle(pair[1], '/unhandled/1.0.0')).to.be.rejected()
+
+    const dialerErr = await expect(dialerResultPromise).to.be.rejected()
+    // Dialer should fail to negotiate the single protocol
+    expect(dialerErr.code).to.eql('ERR_UNSUPPORTED_PROTOCOL')
+  })
 })


### PR DESCRIPTION
Implements lazy select as seen in go-multistream (https://github.com/multiformats/go-multistream/blob/master/lazyClient.go) and rust libp2p (https://github.com/libp2p/rust-libp2p/pull/1855)

Can be used to avoid a round trip when the dialer has only a single protocol to select from.