### PR TITLE
chore: update to handshake 4.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "abortable-iterator": "^4.0.2",
     "err-code": "^3.0.1",
     "it-first": "^1.0.6",
-    "it-handshake": "^4.0.1",
+    "it-handshake": "^4.1.2",
     "it-length-prefixed": "^8.0.2",
     "it-merge": "^1.0.4",
     "it-pipe": "^2.0.3",


### PR DESCRIPTION
**Motivation**

- `it-handshake` 4.0.1 do `Uint8ArrayList.slice()` calls and in the end it call `concat()` with only 1 Uint8Array which sound like a waste since it has to create new memory and do the copy

<img width="792" alt="Screen Shot 2022-10-19 at 16 02 47" src="https://user-images.githubusercontent.com/10568965/196646835-f5059deb-9a6d-4b72-9996-063b4e1d61f0.png">

- The above profile was taken from Lodestar v1.2.0, note that in Lodestar we do a lot of p2p calls

**Description**
- Migrate to latest version of `it-handshake` which I don't see we do the `slice()` call there anymore